### PR TITLE
chore: validate Chromatic required check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # figma2front
 
 Frontend repo consuming @org/design-tokens with auto-rebuild Storybook and MCP integration.
+\n> PR to validate Chromatic required check.


### PR DESCRIPTION
No-op change to trigger Chromatic and record the exact required check name for main protection.